### PR TITLE
Remove unneeded cleanup entries

### DIFF
--- a/com.clarahobbs.chessclock.json
+++ b/com.clarahobbs.chessclock.json
@@ -10,17 +10,6 @@
         "--device=dri",
         "--socket=wayland"
     ],
-    "cleanup" : [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
-    ],
     "modules" : [
         {
             "name" : "chess-clock",
@@ -35,8 +24,5 @@
                 }
             ]
         }
-    ],
-    "build-options" : {
-        "env" : {        }
-    }
+    ]
 }


### PR DESCRIPTION
Following the comments on https://github.com/flathub/flathub/pull/3798, these lines weren't needed.  Just more junk that Gnome Builder included by default, and I copied over without question.