### PR TITLE
Fix screenshots in AppStream data

### DIFF
--- a/com.clarahobbs.chessclock.json
+++ b/com.clarahobbs.chessclock.json
@@ -19,8 +19,7 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/cghobbs/chess-clock.git",
-                    "tag" : "v0.2.0",
-                    "commit" : "ea73b53050cb5ef4fd4e61f706c4299c796da23b"
+                    "commit" : "b06b6e51b19d704d1928f1eb370200b8b1aff411"
                 }
             ]
         }


### PR DESCRIPTION
The screenshots aren't showing up on Flathub or in Gnome Software for the latest release.  Not sure why, so this PR is my attempt to figure it out.